### PR TITLE
DR-895: Update log sink module

### DIFF
--- a/logsink.tf
+++ b/logsink.tf
@@ -57,7 +57,7 @@ module "lb-log-sinks" {
 }
 
 module "user-activity-sinks" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/gcs_bq_log_sink?ref=sinks-0.0.5-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/gcs_bq_log_sink?ref=sinks-0.0.7-tf-0.12"
 
   providers = {
     google = google


### PR DESCRIPTION
Pull in the latest log sink module which fixes the mismatch between the bigquery and sink dataset ids:

- https://github.com/broadinstitute/terraform-shared/pull/88
- https://github.com/broadinstitute/terraform-shared/pull/89
- https://github.com/broadinstitute/terraform-shared/releases/tag/sinks-0.0.7-tf-0.12