### PR TITLE
DR-1098: Add RESTRICTED SSL policy

### DIFF
--- a/modules/core-infrastructure/network.tf
+++ b/modules/core-infrastructure/network.tf
@@ -1,3 +1,8 @@
+resource "google_compute_ssl_policy" "global-ssl-policy" {
+  name            = "global-ssl-policy"
+  profile         = "RESTRICTED"
+  min_tls_version = "TLS_1_2"
+}
 
 resource "google_compute_network" "network" {
   count                   = var.enable ? 1 : 0


### PR DESCRIPTION
Disable TLS <1.2 and old insecure ciphers to comply with FedRAMP policies.