### PR TITLE
Increase Perf db_tier size

### DIFF
--- a/environments/perf/main.tf
+++ b/environments/perf/main.tf
@@ -62,6 +62,7 @@ module "datarepo-app" {
   enable_private_services   = var.enable_private_services
   private_network_self_link = module.core-infrastructure.network-self-link
   dns_zone                  = var.dns_zone
+  db_tier                   = var.db_tier
 
   providers = {
     google.target            = google
@@ -86,7 +87,6 @@ module "datarepo-alerts" {
   ksa_name          = var.ksa_name
   namespace         = var.namespace
   dns_zone          = var.dns_zone
-  db_tier           = var.db_tier
 
   providers = {
     google.target            = google

--- a/environments/perf/main.tf
+++ b/environments/perf/main.tf
@@ -86,6 +86,7 @@ module "datarepo-alerts" {
   ksa_name          = var.ksa_name
   namespace         = var.namespace
   dns_zone          = var.dns_zone
+  db_tier           = var.db_tier
 
   providers = {
     google.target            = google

--- a/environments/perf/variables.tf
+++ b/environments/perf/variables.tf
@@ -115,3 +115,9 @@ variable "roles" {
   default     = ["roles/monitoring.admin", "roles/logging.admin", "roles/monitoring.metricWriter"]
   description = "List of google roles to apply to service account"
 }
+
+variable "db_tier" {
+  type        = string
+  default     = "db-n1-standard-2"
+  description = "DB instance size for the CloudSQL instance"
+}


### PR DESCRIPTION
Ran into following error on perf test run:
`Caught exception: (org.springframework.jdbc.CannotGetJdbcConnectionException: Failed to obtain JDBC Connection; nested exception is org.postgresql.util.PSQLException: FATAL: remaining connection slots are reserved for non-replication superuser connections)`

**Solution**: Increase the VM memory size on the Perf environment to allow for more connections. 
**The Change**: db_tier variable changed from "db-g1-small" to "db-n1-standard-2"