### PR TITLE
Increase Perf db_tier size Followup: Custom db_tier

### DIFF
--- a/environments/perf/main.tf
+++ b/environments/perf/main.tf
@@ -62,7 +62,7 @@ module "datarepo-app" {
   enable_private_services   = var.enable_private_services
   private_network_self_link = module.core-infrastructure.network-self-link
   dns_zone                  = var.dns_zone
-  cloudsql_tier             = var.cloudsql_tier
+  cloudsql_tier             = var.db_tier
 
   providers = {
     google.target            = google

--- a/environments/perf/main.tf
+++ b/environments/perf/main.tf
@@ -62,7 +62,7 @@ module "datarepo-app" {
   enable_private_services   = var.enable_private_services
   private_network_self_link = module.core-infrastructure.network-self-link
   dns_zone                  = var.dns_zone
-  cloudsql_tier             = var.db_tier
+  db_tier                   = var.cloudsql_tier
 
   providers = {
     google.target            = google

--- a/environments/perf/main.tf
+++ b/environments/perf/main.tf
@@ -62,6 +62,7 @@ module "datarepo-app" {
   enable_private_services   = var.enable_private_services
   private_network_self_link = module.core-infrastructure.network-self-link
   dns_zone                  = var.dns_zone
+  cloudsql_tier             = var.cloudsql_tier
 
   providers = {
     google.target            = google

--- a/environments/perf/terraform.sh
+++ b/environments/perf/terraform.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEFAULT_TERRAFORM_VERSION="0.12.24"
+DEFAULT_TERRAFORM_VERSION="0.12.29"
 #DOCKER_IMAGE='broadinstitute/terraform:latest'
 DOCKER_IMAGE="${DOCKER_IMAGE:-gcr.io/broad-dsp-gcr-public/terraform0.12:${TERRAFORM_VERSION:-${DEFAULT_TERRAFORM_VERSION}}}"
 SUDO=

--- a/environments/perf/variables.tf
+++ b/environments/perf/variables.tf
@@ -116,7 +116,7 @@ variable "roles" {
   description = "List of google roles to apply to service account"
 }
 
-variable "db_tier" {
+variable "cloudsql_tier" {
   type        = string
   default     = "db-custom-16-32768" # match sam postgres in prod
   description = "Custom tier (DB instance size) for CloudSQL instances"

--- a/environments/perf/variables.tf
+++ b/environments/perf/variables.tf
@@ -116,7 +116,7 @@ variable "roles" {
   description = "List of google roles to apply to service account"
 }
 
-variable "cloudsql_tier" {
+variable "db_tier" {
   type        = string
   default     = "db-custom-16-32768" # match sam postgres in prod
   description = "Custom tier (DB instance size) for CloudSQL instances"

--- a/environments/perf/variables.tf
+++ b/environments/perf/variables.tf
@@ -94,7 +94,7 @@ variable "host" {
 
 variable "namespace" {
   type        = string
-  default     = "terra-alpha"
+  default     = "monitoring"
   description = "kubernetes namespace"
 }
 

--- a/environments/perf/variables.tf
+++ b/environments/perf/variables.tf
@@ -115,3 +115,9 @@ variable "roles" {
   default     = ["roles/monitoring.admin", "roles/logging.admin", "roles/monitoring.metricWriter"]
   description = "List of google roles to apply to service account"
 }
+
+variable "cloudsql_tier" {
+  type        = string
+  default     = "db-custom-16-32768" # match sam postgres in prod
+  description = "Custom tier (DB instance size) for CloudSQL instances"
+}


### PR DESCRIPTION
Follow up to [Increase Perf db_tier size](https://github.com/broadinstitute/terraform-jade/pull/90). 

## Change (1) - Custom Tier
On merging the PR, we encountered the following error:
`Error, failed to update instance settings for : googleapi: Error 400: Invalid request: Only custom machine instance type and shared-core instance type allowed for PostgreSQL database., invalid`

So, instead of switching to db_tier to db-n1-standard-2, we needed to create a custom tier. 

As this [forum](https://github.com/hashicorp/terraform/issues/12617#issuecomment-298617855) explains, you can create a custom tier just by following this pattern:
`db-custom-{NUMBER_OF_CPUS}-{MEMORY_IN_MIB}`

@smark88 found other examples for how we set the custom tier in terra: https://github.com/broadinstitute/terraform-shared/blob/master/terraform-modules/cloudsql-postgres/variables.tf#L60

We are following this precedence, and using the same custom tier setting for perf. 

## Change (2) - Change variable name to cloudsql_tier
This follows the naming precedence used across our other terraformed code. 