### PR TITLE
Revert "Add projectIamAdmin role to test runner"

### DIFF
--- a/modules/datarepo-app/variables.tf
+++ b/modules/datarepo-app/variables.tf
@@ -59,11 +59,10 @@ locals {
 
 locals {
   test_runner_roles = [
-    "roles/container.admin",                # Kubernetes Engine Admin
-    "roles/logging.viewer",                 # Logs Viewer
-    "roles/monitoring.viewer",              # Monitoring Viewer
-    "roles/secretmanager.admin",            # Secret Manager Admin
-    "roles/resourcemanager.projectIamAdmin" # Project IAM Admin
+    "roles/container.admin",    # Kubernetes Engine Admin
+    "roles/logging.viewer",     # Logs Viewer
+    "roles/monitoring.viewer",  # Monitoring Viewer
+    "roles/secretmanager.admin" # Secret Manager Admin
   ]
 }
 


### PR DESCRIPTION
This permission isn't actually useful because we're cleaning the `-data` project, not the `server` project.

This reverts commit 3942614db7b5620583d80fdf2a09d3a9ffd24dad.