### PR TITLE
Grant Jade SA owner role on RBS-created projects

### DIFF
--- a/datarepo/modules/datarepo-app/variables.tf
+++ b/datarepo/modules/datarepo-app/variables.tf
@@ -59,6 +59,7 @@ locals {
     "roles/resourcemanager.folderAdmin",
     "roles/resourcemanager.projectCreator",
     "roles/resourcemanager.projectDeleter",
+    "roles/owner"
   ]
   folder_ids_and_roles = [
     for pair in setproduct(local.app_folder_roles, var.external_folder_ids) : {

--- a/datarepo/variables.tf
+++ b/datarepo/variables.tf
@@ -180,7 +180,7 @@ variable "enable_monitoring" {
   type    = bool
 }
 
-variable external_folder_ids {
+variable "external_folder_ids" {
   type        = list(string)
   description = "Folder ids used by RBS"
   default     = []

--- a/old/iam.tf
+++ b/old/iam.tf
@@ -31,7 +31,7 @@ variable "jadeteam-roles" {
 }
 
 variable "app_folder_roles" {
-  type = list(string)
+  type        = list(string)
   description = "Roles used to manage projects created by the resource buffer service"
   default = [
     "roles/resourcemanager.folderAdmin",
@@ -44,7 +44,7 @@ variable "app_folder_roles" {
 variable "external_folder_ids" {
   type        = list(string)
   description = "Folder ids used by RBS"
-  default     = [
+  default = [
     "270278425081" # data.test-terra.bio/repos/jade-dev
   ]
 }
@@ -53,7 +53,7 @@ locals {
   folder_ids_and_roles = [
     for pair in setproduct(var.app_folder_roles, var.external_folder_ids) : {
       folder_role = pair[0]
-      folder_id = pair[1]
+      folder_id   = pair[1]
     }
   ]
 }

--- a/old/iam.tf
+++ b/old/iam.tf
@@ -37,6 +37,7 @@ variable "app_folder_roles" {
     "roles/resourcemanager.folderAdmin",
     "roles/resourcemanager.projectCreator",
     "roles/resourcemanager.projectDeleter",
+    "roles/owner"
   ]
 }
 


### PR DESCRIPTION
Since the RBS service is creating google projects, the Jade SA no longer has the owner role by default so we add it here. This is required in order to create project resources such as firestore and bigquery.