### PR TITLE
DDO-1832 Ignore updates to TDR api sa key, so that we can implement automatic rotation

### DIFF
--- a/datarepo/modules/datarepo-app/serviceaccounts.tf
+++ b/datarepo/modules/datarepo-app/serviceaccounts.tf
@@ -46,6 +46,10 @@ resource "vault_generic_secret" "api_sa_key" {
   "key": "${google_service_account_key.api_sa_key[0].private_key}"
 }
 EOT
+
+  lifecycle {
+    ignore_changes = [data_json] # Ignore changes since this key is automatically rotated
+  }
 }
 
 ## test-runner-sa


### PR DESCRIPTION
DevOps will add the prod key to the list that are auto-rotated by yale