### PR TITLE
DR-2336 Add projectMover and secure folder ids

### DIFF
--- a/datarepo/modules/datarepo-app/variables.tf
+++ b/datarepo/modules/datarepo-app/variables.tf
@@ -64,6 +64,7 @@ locals {
     "roles/resourcemanager.folderAdmin",
     "roles/resourcemanager.projectCreator",
     "roles/resourcemanager.projectDeleter",
+    "roles/resourcemanager.projectMover",
     "roles/owner"
   ]
   folder_ids_and_roles = [

--- a/datarepo/tfvars/alpha.tfvars
+++ b/datarepo/tfvars/alpha.tfvars
@@ -11,7 +11,7 @@ datarepo_namespace = "terra-alpha"
 sql_ksa_name       = "datarepo-gcloud-sqlproxy"
 external_folder_ids = [
   "270278425081", # data.test-terra.bio/repos/jade-dev
-  "753276429356", # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
+  "753276429356" # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
 ]
 ## alerting
 host     = "data.alpha.envs-terra.bio"

--- a/datarepo/tfvars/alpha.tfvars
+++ b/datarepo/tfvars/alpha.tfvars
@@ -10,7 +10,8 @@ argocd_cidrs       = ["34.68.105.207/32", "35.184.212.129/32"]
 datarepo_namespace = "terra-alpha"
 sql_ksa_name       = "datarepo-gcloud-sqlproxy"
 external_folder_ids = [
-"270278425081" # data.test-terra.bio/repos/jade-dev
+  "270278425081", # data.test-terra.bio/repos/jade-dev
+  "753276429356", # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
 ]
 ## alerting
 host     = "data.alpha.envs-terra.bio"

--- a/datarepo/tfvars/perf.tfvars
+++ b/datarepo/tfvars/perf.tfvars
@@ -12,7 +12,8 @@ cloudsql_tier      = "db-custom-16-32768"
 datarepo_namespace = "perf"
 sql_ksa_name       = "perf-jade-gcloud-sqlproxy"
 external_folder_ids = [
-"270278425081" # data.test-terra.bio/repos/jade-dev
+  "270278425081", # data.test-terra.bio/repos/jade-dev
+  "753276429356", # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
 ]
 ## alerting
 host     = "jade-perf.datarepo-perf.broadinstitute.org"

--- a/datarepo/tfvars/perf.tfvars
+++ b/datarepo/tfvars/perf.tfvars
@@ -13,7 +13,7 @@ datarepo_namespace = "perf"
 sql_ksa_name       = "perf-jade-gcloud-sqlproxy"
 external_folder_ids = [
   "270278425081", # data.test-terra.bio/repos/jade-dev
-  "753276429356", # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
+  "753276429356" # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
 ]
 ## alerting
 host     = "jade-perf.datarepo-perf.broadinstitute.org"

--- a/datarepo/tfvars/production.tfvars
+++ b/datarepo/tfvars/production.tfvars
@@ -19,7 +19,8 @@ argocd_cidrs       = ["34.68.105.207/32", "35.184.212.129/32"]
 datarepo_namespace = "terra-prod"
 sql_ksa_name       = "datarepo-gcloud-sqlproxy"
 external_folder_ids = [
-  "815384374864" # firecloud.org/terra-datarepo
+  "815384374864", # firecloud.org/terra-datarepo
+  "43241207445" # firecloud.org/terra-datarepo-secure
 ]
 ## alerting
 host     = "data.terra.bio"

--- a/datarepo/tfvars/staging.tfvars
+++ b/datarepo/tfvars/staging.tfvars
@@ -11,7 +11,7 @@ datarepo_namespace = "terra-staging"
 sql_ksa_name       = "datarepo-gcloud-sqlproxy"
 external_folder_ids = [
   "270278425081", # data.test-terra.bio/repos/jade-dev  "270278425081", # data.test-terra.bio/repos/jade-dev
-  "753276429356", # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
+  "753276429356" # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
 ]
 ## alerting
 host     = "data.staging.envs-terra.bio"

--- a/datarepo/tfvars/staging.tfvars
+++ b/datarepo/tfvars/staging.tfvars
@@ -10,7 +10,8 @@ argocd_cidrs       = ["34.68.105.207/32", "35.184.212.129/32"]
 datarepo_namespace = "terra-staging"
 sql_ksa_name       = "datarepo-gcloud-sqlproxy"
 external_folder_ids = [
-"270278425081" # data.test-terra.bio/repos/jade-dev
+  "270278425081", # data.test-terra.bio/repos/jade-dev  "270278425081", # data.test-terra.bio/repos/jade-dev
+  "753276429356", # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
 ]
 ## alerting
 host     = "data.staging.envs-terra.bio"

--- a/datarepo/tfvars/staging.tfvars
+++ b/datarepo/tfvars/staging.tfvars
@@ -10,7 +10,7 @@ argocd_cidrs       = ["34.68.105.207/32", "35.184.212.129/32"]
 datarepo_namespace = "terra-staging"
 sql_ksa_name       = "datarepo-gcloud-sqlproxy"
 external_folder_ids = [
-  "270278425081", # data.test-terra.bio/repos/jade-dev  "270278425081", # data.test-terra.bio/repos/jade-dev
+  "270278425081", # data.test-terra.bio/repos/jade-dev
   "753276429356" # data.test-terra.bio/repos/jade-dev/jade-dev-refoldering-test
 ]
 ## alerting


### PR DESCRIPTION
API service accounts need permissions to be able to move folders around. Putting it in TF instead of configuring by hand in GCP