### PR TITLE
DR-2358 Downsize Perf CloudSQL Instance

### DIFF
--- a/datarepo/tfvars/perf.tfvars
+++ b/datarepo/tfvars/perf.tfvars
@@ -8,7 +8,6 @@ environment        = "perf"
 ip_only            = "false"
 dns_zone           = "datarepo-perf"
 argocd_cidrs       = ["35.202.125.180/32", "34.70.76.7/32"]
-cloudsql_tier      = "db-custom-16-32768"
 datarepo_namespace = "perf"
 sql_ksa_name       = "perf-jade-gcloud-sqlproxy"
 external_folder_ids = [


### PR DESCRIPTION
Perf is using a massive 16CPU/32GB instance for CloudSQL, but we come nowhere near utilizing even 5% of that capacity. Perf is special-cased to use this massive machine, whereas everything else uses a 2CPU/7.5GB configuration. Making Perf use the same configuration as all the other environments should save us ~$1000 per month.