### PR TITLE
[DDO-3234] Add dsp-tools-k8s IPs to the allowed CIDRs in old dev

### DIFF
--- a/old/variables.tf.ctmpl
+++ b/old/variables.tf.ctmpl
@@ -63,7 +63,13 @@ variable "broad_range_cidrs" {
   "69.173.96.0/20",
   "69.173.64.0/19",
   "69.173.127.192/27",
-  "69.173.124.0/23"
+  "69.173.124.0/23",
+  # These last two are actually for DevOps's dsp-tools-k8s cluster, which
+  # should be able to access old jade-dev resources as if they were on VPN.
+  # Allowing dsp-tools-k8s to access clusters this way is actually the same
+  # thing DevOps configures for all the clusters it directly manages.
+  "34.68.105.207/32",
+  "35.184.212.129/32"
   ]
 }
 


### PR DESCRIPTION
See https://broadinstitute.slack.com/archives/CD4HBRFMG/p1697642737972479 and DDO-3234 for context. **There is no need to apply these changes, I already did them in the UI.** I just wanted to avoid any surprises with the Terraform not applying for some other reason, since it does seem a bit old.

The IP addresses are taken directly from what we use for all the DevOps clusters [here](https://github.com/broadinstitute/terraform-ap-deployments/blob/master/terra-cluster/cidrs.tf#L25). They come from the dsp-tools-k8s NAT.